### PR TITLE
fix extern c

### DIFF
--- a/lib/std/mem.zig
+++ b/lib/std/mem.zig
@@ -1055,8 +1055,8 @@ const backend_supports_vectors = switch (builtin.zig_backend) {
     else => false,
 };
 
-extern "C" fn wcslen(s: [*:0]const u16) usize;
-extern "C" fn strlen(s: [*:0]const u8) usize;
+extern "c" fn wcslen(s: [*:0]const u16) usize;
+extern "c" fn strlen(s: [*:0]const u8) usize;
 
 pub fn indexOfSentinel(comptime T: type, comptime sentinel: T, p: [*:sentinel]const T) usize {
     if (comptime T == u16 and sentinel == 0 and builtin.target.os.tag == .windows) {


### PR DESCRIPTION
In Zig, its
```zig
extern "c"
```
, not
```zig
extern "C"
```