### PR TITLE
partially revert b11877f

### DIFF
--- a/lib/std/mem.zig
+++ b/lib/std/mem.zig
@@ -1055,17 +1055,7 @@ const backend_supports_vectors = switch (builtin.zig_backend) {
     else => false,
 };
 
-extern "c" fn wcslen(s: [*:0]const u16) usize;
-extern "c" fn strlen(s: [*:0]const u8) usize;
-
 pub fn indexOfSentinel(comptime T: type, comptime sentinel: T, p: [*:sentinel]const T) usize {
-    if (comptime T == u16 and sentinel == 0 and builtin.target.os.tag == .windows) {
-        return wcslen(p);
-    }
-    if (comptime T == u8 and sentinel == 0) {
-        return strlen(p);
-    }
-
     var i: usize = 0;
 
     if (backend_supports_vectors and


### PR DESCRIPTION
@Jarred-Sumner Sorry #3 did not fix the build failure on WSL. The problem was that using `extern "C"` uses strlen from `libc`, and this cannot be done because bun executable does not link libc. So if this is part of this code not necessary, we should remove it.

@nektro I see you are the author of this change. Is this a necessary change?