### PR TITLE
`chmod +x` x86_64 ReleaseSafe builds

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -59,8 +59,11 @@ jobs:
       - name: chmod
         run: |
           chmod +x bootstrap-x86_64-macos-none/zig
+          chmod +x bootstrap-x86_64-macos-none-ReleaseSafe/zig
           chmod +x bootstrap-x86_64-linux-musl/zig
+          chmod +x bootstrap-x86_64-linux-musl-ReleaseSafe/zig
           chmod +x bootstrap-x86_64-windows-gnu/zig.exe
+          chmod +x bootstrap-x86_64-windows-gnu-ReleaseSafe/zig.exe
           chmod +x bootstrap-aarch64-macos-none/zig
           chmod +x bootstrap-aarch64-macos-none-ReleaseSafe/zig
           chmod +x bootstrap-aarch64-linux-musl/zig


### PR DESCRIPTION
This was a problem for me when trying to do `CI=1 bun build:asan`, because the CI variable implies `ZIG_COMPILER_SAFE=ON` in CMake, and I'm on an x86-64 Linux platform.